### PR TITLE
Use more specific url patterns

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -21,7 +21,9 @@
   "content_scripts": [
     {
       "matches": [
-        "<all_urls>"
+        "file://*/*",
+        "http://*/*",
+        "https://*/*"
       ],
       "js": ["contentScript.js"],
       "run_at": "document_start"


### PR DESCRIPTION
This is an attempt to shorten the review time from Chrome Store when publishing Kambani. I am not sure if it will be successful, but we should anyways use these more specific URL patterns IMO. 