### PR TITLE
Fix typo in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Example code:
   window.addEventListener("KambaniInstalled", event => {
     console.log("Kambani is installed")
   })
-  window.dispatchEvent(new CustomEvent("IsKambaniInstalled))
+  window.dispatchEvent(new CustomEvent("IsKambaniInstalled"))
 ```
 
 ### FCT addresses request


### PR DESCRIPTION
Add missing quotation mark to "IsKambaniInstalled" example